### PR TITLE
allow client to control rotation by CLI arg 'rotate'

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -93,12 +93,17 @@ fn main() -> Result<(), Error> {
                 .long("graypoint")
                 .takes_value(true),
         )
-          .arg(
+        .arg(
             Arg::with_name("WHITECUTOFF")
                 .help("apply a post processing filter to turn colors greater than the specified value to white (255)")
                 .long("whitecutoff")
                 .takes_value(true),
-        )
+        ).arg(
+            Arg::with_name("ROTATE")
+                .help("rotation (1-4), tested on a Clara HD, try at own risk")
+                .long("rotate")
+                .takes_value(true),
+        ) 
         .get_matches();
 
     let host = matches.value_of("HOST").unwrap();
@@ -109,6 +114,7 @@ fn main() -> Result<(), Error> {
     let contrast_gray_point = value_t!(matches.value_of("GRAYPOINT"), f32).unwrap_or(224.0);
     let white_cutoff = value_t!(matches.value_of("WHITECUTOFF"), u8).unwrap_or(255);
     let exclusive = matches.is_present("EXCLUSIVE");
+    let rotate = value_t!(matches.value_of("ROTATE"), i8).unwrap_or(1);
 
     info!("connecting to {}:{}", host, port);
     let stream = match std::net::TcpStream::connect((host, port)) {
@@ -212,7 +218,7 @@ fn main() -> Result<(), Error> {
 
     #[cfg(feature = "eink_device")]
     {
-        let startup_rotation = 1;
+        let startup_rotation = rotate;
         fb.set_rotation(startup_rotation).ok();
     }
 


### PR DESCRIPTION
allow to rotate the VNC client to wide-screen mode; helps to use einkvnc in landscape mode on Kobo Elipsa2E

![rotate-arg](https://github.com/user-attachments/assets/c95d532e-6bfe-474b-9f80-e1f1b898f59e)

inspired by:
https://www.mobileread.com/forums/showpost.php?p=4313868&postcount=19